### PR TITLE
Added parameter to control header

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -52,7 +52,9 @@
 #let boxedsheet(
   title: [],
   homepage: "",
-  authors: (),
+  authors: "",
+  write-header: true,
+  write-header-homepage: true,
   write-title: false,
   title-align: center,
   title-number: true,
@@ -66,31 +68,39 @@
   column-gutter: 4pt,
   numbered-units: false,
   color-box: default-color-box,
-  body) = {
+  body,
+) = {
 
     color-box-state.update(color-box)
 
     set page(
-      paper: "a4",
+      width: page-w,
+      height: page-h,
       flipped: true,
       margin: (x: x-margin, y: y-margin),
       header: [
-        #grid(
-          columns: (1fr, 1fr, 1fr),
-          align: (left, center, right),
-          gutter: 0pt,
-          [
-            #text(datetime.today().display("[month repr:long] [day], [year]"), weight: "bold")
-          ],
-          [
-            #text(title, weight: "bold")
-          ],
-          [
-            #text(authors + " @ " + homepage, weight: "bold")
-          ]
-        )
-        #v(-3pt)
-        #line(length: 100%, stroke: black)
+        #if write-header [
+	        #grid(
+	          columns: (1fr, 1fr, 1fr),
+	          align: (left, center, right),
+	          gutter: 0pt,
+	          [
+	            #text(datetime.today().display("[month repr:long] [day], [year]"), weight: "bold")
+	          ],
+	          [
+	            #text(title, weight: "bold")
+	          ],
+	          [
+			  #if write-header-homepage [
+			    #text(authors + " @ " + homepage, weight: "bold")
+			  ] else [
+			    #text(authors, weight: "bold")
+			  ]
+	          ]
+	        )
+	        #v(-3pt)
+	        #line(length: 100%, stroke: black)
+        ]
       ]
     )
     
@@ -147,7 +157,9 @@
 #let boxedsheet-scaling(
   title: [],
   homepage: "",
-  authors: (),
+  authors: "",
+  write-header: true,
+  write-header-homepage: true,
   write-title: false,
   title-align: center,
   page-w: auto,
@@ -163,7 +175,8 @@
   column-gutter: 4pt,
   numbered-units: false,
   color-box: default-color-box,
-  body) = {
+  body,
+) = {
 
     color-box-state.update(color-box)
 
@@ -173,22 +186,28 @@
       flipped: true,
       margin: (x: x-margin, y: y-margin),
       header: [
-        #grid(
-          columns: (1fr, 1fr, 1fr),
-          align: (left, center, right),
-          gutter: 0pt,
-          [
-            #text(datetime.today().display("[month repr:long] [day], [year]"), weight: "bold")
-          ],
-          [
-            #text(title, weight: "bold")
-          ],
-          [
-            #text(authors + " @ " + homepage, weight: "bold")
-          ]
-        )
-        #v(-3pt)
-        #line(length: 100%, stroke: black)
+        #if write-header [
+	        #grid(
+	          columns: (1fr, 1fr, 1fr),
+	          align: (left, center, right),
+	          gutter: 0pt,
+	          [
+	            #text(datetime.today().display("[month repr:long] [day], [year]"), weight: "bold")
+	          ],
+	          [
+	            #text(title, weight: "bold")
+	          ],
+	          [
+			  #if write-header-homepage [
+			    #text(authors + " @ " + homepage, weight: "bold")
+			  ] else [
+			    #text(authors, weight: "bold")
+			  ]
+	          ]
+	        )
+	        #v(-3pt)
+	        #line(length: 100%, stroke: black)
+        ]
       ]
     )
     

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -74,8 +74,7 @@
     color-box-state.update(color-box)
 
     set page(
-      width: page-w,
-      height: page-h,
+      paper: "a4",
       flipped: true,
       margin: (x: x-margin, y: y-margin),
       header: [
@@ -103,7 +102,7 @@
         ]
       ]
     )
-    
+
     set text(size: font-size)
 
     set heading(numbering: "1.1") if title-number
@@ -210,7 +209,7 @@
         ]
       ]
     )
-    
+
     set text(size: font-size)
 
     set heading(numbering: "1.1") if title-number


### PR DESCRIPTION
Hi!

I hope PRs are okay.

This adds a couple of parameters to control the way the header is written.
- Disable header completely
- Disable writing homepage

The changes are non-breaking, even the default behaviour remains the same.

Examples:
Without homepage:
<img width="1183" height="98" alt="image" src="https://github.com/user-attachments/assets/e6ebddfe-cb62-4fe1-b1af-27ba8d46b7d5" />

Without header:
<img width="1224" height="112" alt="image" src="https://github.com/user-attachments/assets/181d965d-7eee-44de-bd72-310c18c9719f" />

---

Unrelated change: The parameter `author: ()` is never valid since it's concatenated with `@` later on if homepage is enabled, so I changed it to an empty string so that it compiles even if author is omitted for nameless documents.

Cheers!